### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.md
@@ -1,0 +1,40 @@
+---
+name: '🐞 Bug report'
+about: 'Create a report to help us improve Plone'
+title: ''
+labels: ['01 type: bug', '30 needs: triage']
+assignees: ''
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+
+If applicable, add screenshots or videos to help explain your problem.
+
+**Software (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. firefox, chrome, safari]
+- Plone Version [e.g. 6.1.0]
+- Volto Version [e.g. 18.4.0]
+- Plone REST API Version [e.g. 9.1.0]
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/1_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.md
@@ -6,6 +6,11 @@ labels: ['01 type: bug', '30 needs: triage']
 assignees: ''
 ---
 
+> [!CAUTION]
+> Do not file security issues in this tracker.
+> Send email to security@plone.org instead.
+> See [Report a security issue](https://plone.org/security/report).
+
 **Describe the bug**
 
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/2_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.md
@@ -1,0 +1,23 @@
+---
+name: '🦄 Feature request'
+about: 'Suggest an idea for Plone'
+title: ''
+labels: '04 type: enhancement'
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Example: I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/3_PLIP.md
+++ b/.github/ISSUE_TEMPLATE/3_PLIP.md
@@ -1,0 +1,76 @@
+---
+name: '🚀 PLIP'
+about: 'A Plone Improvement Proposal (PLIP) is a change to a Plone package that would affect everyone who uses that package.'
+title: ''
+labels: '03 type: feature (plip)'
+type: 'PLIP'
+assignees: ''
+projects: 'plone/47'
+---
+
+<!-- Keep this admonition when you submit your PLIP -->
+
+> [!IMPORTANT]
+> If you are not a member of the Developers Team in the Plone GitHub organization, then do not work on or comment on this issue.
+
+## PLIP (Plone Improvement Proposal)
+
+<!--
+
+Read https://6.docs.plone.org/contributing/core/plips.html first!
+
+Set "03 type: feature: plip" as label.
+
+Mention the appropriate team when the PLIP is information complete!
+
+@plone/ClassicUI-Team
+@plone/developers
+@plone/framework-team
+@plone/restapi-team
+@plone/volto-team
+
+-->
+
+## Responsible Persons
+
+### Proposer: <!-- full NAME of the proposer, should lead the PLIP - if not possible, tell about it! -->
+
+### Seconder: <!-- NAME of another person supporting this PLIP -->
+
+## Abstract
+
+<!-- a comprehensive overview of the subject -->
+
+## Motivation
+
+<!--
+Reason or motivation this proposal was created
+-->
+
+## Assumptions
+
+<!-- Preconditions -->
+
+## Proposal & Implementation
+
+<!--
+Detailed proposal with implementation details and - if needed - possible variants to be discussed.
+-->
+
+## Deliverables
+
+<!--
+Packages and documentation chapters involved, includes also third party if needed.
+-->
+
+## Risks
+
+<!--
+What will break/ affect existing installations of Plone after upgrade, including end user point of view, training efforts etc.
+-->
+
+## Participants
+
+<!--
+list of persons and roles known
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Get support
+    url: https://community.plone.org/
+    about: Get support for Plone in the Community Forum.
+  - name: Chat
+    url: https://discord.gg/zFY3EBbjaj
+    about: Chat on Discord.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,6 @@
-blank_issues_enabled: false
+# Set to false to force a choice. May annoy maintainers, but will allow
+# automatic application of labels according to the selection.
+blank_issues_enabled: true
 contact_links:
   - name: Get support
     url: https://community.plone.org/
@@ -6,3 +8,6 @@ contact_links:
   - name: Chat
     url: https://discord.gg/zFY3EBbjaj
     about: Chat on Discord.
+  - name: Report a security issue
+    url: https://plone.org/security/report
+    about: Report a security issue.


### PR DESCRIPTION
This PR adds issue templates. They're basic and can be overridden per repo.

A good demo can be found at https://github.com/plone/volto/issues/new/choose.

See https://github.com/plone/.github/community to see current community health status.